### PR TITLE
FIx undefinded export error when used in JS

### DIFF
--- a/packages/worker-api/src/index.ts
+++ b/packages/worker-api/src/index.ts
@@ -1,3 +1,3 @@
 export { EncointerWorker } from './worker';
 
-export { IEncointerWorker, WorkerOptions, CallOptions, PubKeyPinPair } from './interface';
+export * from './interface';


### PR DESCRIPTION
When using this lib in a js environment, an undefined export error (warning in webpack 4) is thrown when there are named re-exports of interfaces because they disappear after they have been compiled to js. Hence, a wildcard reexport is needed.