### PR TITLE
Update rpc prefixes

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: build-and-test.yml
-          name: encointer-node-notee-8ac46d1aec5ccace957e959e6a1f69f372f149eb
+          name: encointer-node-notee-0fb5bb3b1fb452f90a30a6324c5c2f667a031836
           # in fact this action should download the latest artifact, but sometimes fails. Then we need to
           # set the `run_id` to force a download of an updated binary.
-          run_id: 2009840024
+          run_id: 2166654040
           path: node
           repo: encointer/encointer-node
 

--- a/packages/node-api/src/e2e.ts
+++ b/packages/node-api/src/e2e.ts
@@ -54,6 +54,9 @@ describe('node-api', () => {
                 provider: provider
             });
             console.log(`${chain} wss connected success`);
+            console.log(
+                `rpc-methods ${await  api.rpc.rpc.methods()}`
+            );
         } catch (err) {
             console.log(`connect ${chain} failed`);
             await provider.disconnect();
@@ -188,8 +191,8 @@ describe('node-api', () => {
 
     describe('rpc', () => {
         // These tests predominantly verify that we have correct rpc/type definitions
-        describe('ceremonies', () => {
-            it('ceremonies.getReputations should return empty vec', async () => {
+        describe('encointer', () => {
+            it('encointer.getReputations should return empty vec', async () => {
                 // @ts-ignore
                 const reputations = await api.rpc.encointer.getReputations(alice.address);
 
@@ -197,16 +200,14 @@ describe('node-api', () => {
 
                 expect(reputations.length).toBe(0)
             });
-        });
 
-        describe('communities', () => {
-            it('communities.GetAll should return empty vec', async () => {
+            it('encointer.GetAllCommunities should return empty vec', async () => {
                 // @ts-ignore
                 const cidNames = await api.rpc.encointer.getAllCommunities();
                 expect(cidNames[0].cid).toStrictEqual(cidMTA);
             });
 
-            it('communities.getLocations should return error on unknown community', async () => {
+            it('encointer.getLocations should return error on unknown community', async () => {
                 let cid = communityIdentifierFromString(api.registry, "gbsuv7YXq9G")
 
                 try {
@@ -218,7 +219,7 @@ describe('node-api', () => {
 
             });
 
-            it('communities.getAllBalances should return empty vec', async () => {
+            it('encointer.getAllBalances should return empty vec', async () => {
                 // @ts-ignore
                 const balances = await api.rpc.encointer.getAllBalances(alice.address);
 
@@ -230,7 +231,7 @@ describe('node-api', () => {
         });
 
         describe('bazaar', () => {
-            it('bazaar.GetBusinesses should return empty vec', async () => {
+            it('encointer.bazaarGetBusinesses should return empty vec', async () => {
                 const cid = api.createType('CommunityIdentifier', {
                     geohash: [0x00, 0x00, 0x00, 0x00, 0x00],
                     digest: [0x00, 0x00, 0x00, 0x00,],
@@ -242,7 +243,7 @@ describe('node-api', () => {
                 expect(result.length).toBe(0);
             });
 
-            it('bazaar.GetOfferings should return empty vec', async () => {
+            it('encointer.bazaarGetOfferings should return empty vec', async () => {
                 // random cid
                 let cid = communityIdentifierFromString(api.registry, "gbsuv7YXq9G")
                 // @ts-ignore
@@ -251,14 +252,14 @@ describe('node-api', () => {
                 expect(result.length).toBe(0);
             });
 
-            it('bazaar.GetOfferingsForBusiness should return empty vec', async () => {
+            it('encointer.bazaarGetOfferingsForBusiness should return empty vec', async () => {
                 // random cid
                 let cid = communityIdentifierFromString(api.registry, "gbsuv7YXq9G")
                 const alice = keyring.addFromUri('//Alice', {name: 'Alice default'})
 
                 const bid = api.createType('BusinessIdentifier', [cid, alice.publicKey]);
                 // @ts-ignore
-                const result = await api.rpc.encoiner.bazaarGetOfferingsForBusiness(bid);
+                const result = await api.rpc.encointer.bazaarGetOfferingsForBusiness(bid);
                 // console.log(result);
                 expect(result.length).toBe(0);
             });

--- a/packages/node-api/src/e2e.ts
+++ b/packages/node-api/src/e2e.ts
@@ -191,7 +191,7 @@ describe('node-api', () => {
         describe('ceremonies', () => {
             it('ceremonies.getReputations should return empty vec', async () => {
                 // @ts-ignore
-                const reputations = await api.rpc.ceremonies.getReputations(alice.address);
+                const reputations = await api.rpc.encointer.getReputations(alice.address);
 
                 // console.log(`Reputations: ${JSON.stringify(reputations)}`);
 
@@ -202,7 +202,7 @@ describe('node-api', () => {
         describe('communities', () => {
             it('communities.GetAll should return empty vec', async () => {
                 // @ts-ignore
-                const cidNames = await api.rpc.communities.getAll();
+                const cidNames = await api.rpc.encointer.getAllCommunities();
                 expect(cidNames[0].cid).toStrictEqual(cidMTA);
             });
 
@@ -211,7 +211,7 @@ describe('node-api', () => {
 
                 try {
                     // @ts-ignore
-                    await api.rpc.communities.getLocations(cid)
+                    await api.rpc.encointer.getLocations(cid)
                 } catch (e: any) {
                     expect(e.toString()).toBe("Error: 3: Offchain storage not found: Key [99, 105, 100, 115, 103, 98, 115, 117, 118, 255, 255, 255, 255]");
                 }
@@ -220,7 +220,7 @@ describe('node-api', () => {
 
             it('communities.getAllBalances should return empty vec', async () => {
                 // @ts-ignore
-                const balances = await api.rpc.communities.getAllBalances(alice.address);
+                const balances = await api.rpc.encointer.getAllBalances(alice.address);
 
                 // console.log(`balances: ${JSON.stringify(balances)}`);
 
@@ -237,7 +237,7 @@ describe('node-api', () => {
                 });
 
                 // @ts-ignore
-                const result = await api.rpc.bazaar.getBusinesses(cid.toHex());
+                const result = await api.rpc.encointer.bazaarGetBusinesses(cid.toHex());
                 // console.log(result);
                 expect(result.length).toBe(0);
             });
@@ -246,7 +246,7 @@ describe('node-api', () => {
                 // random cid
                 let cid = communityIdentifierFromString(api.registry, "gbsuv7YXq9G")
                 // @ts-ignore
-                const result = await api.rpc.bazaar.getOfferings(cid);
+                const result = await api.rpc.encointer.bazaarGetOfferings(cid);
                 // console.log(result);
                 expect(result.length).toBe(0);
             });
@@ -258,7 +258,7 @@ describe('node-api', () => {
 
                 const bid = api.createType('BusinessIdentifier', [cid, alice.publicKey]);
                 // @ts-ignore
-                const result = await api.rpc.bazaar.getOfferingsForBusiness(bid);
+                const result = await api.rpc.encoiner.bazaarGetOfferingsForBusiness(bid);
                 // console.log(result);
                 expect(result.length).toBe(0);
             });

--- a/packages/node-api/src/encointer-api.ts
+++ b/packages/node-api/src/encointer-api.ts
@@ -85,7 +85,7 @@ export async function getMeetupLocation(api: ApiPromise, cid: CommunityIdentifie
 
     const [locations, assignmentParams] = await Promise.all([
         // @ts-ignore
-        api.rpc.communities.getLocations(cid),
+        api.rpc.encointer.getLocations(cid),
         getAssignment(api, cid, cIndex)
     ]);
 

--- a/packages/types/src/interfaces/bazaar/definitions.ts
+++ b/packages/types/src/interfaces/bazaar/definitions.ts
@@ -1,7 +1,7 @@
 export default {
     rpc: {
-        bazaar: {
-            getBusinesses: {
+        encointer: {
+            bazaarGetBusinesses: {
                 description: 'Get all businesses in a Community',
                 params: [
                     {
@@ -17,7 +17,7 @@ export default {
                 ],
                 type: 'Vec<BusinessData>'
             },
-            getOfferings: {
+            bazaarGetOfferings: {
                 description: 'Get all offerings in a Community',
                 params: [
                     {
@@ -33,7 +33,7 @@ export default {
                 ],
                 type: 'Vec<OfferingData>'
             },
-            getOfferingsForBusiness: {
+            bazaarGetOfferingsForBusiness: {
                 description: 'Get all offerings of a business',
                 params: [
                     {

--- a/packages/types/src/interfaces/bazaar/definitions.ts
+++ b/packages/types/src/interfaces/bazaar/definitions.ts
@@ -1,56 +1,5 @@
 export default {
-    rpc: {
-        encointer: {
-            bazaarGetBusinesses: {
-                description: 'Get all businesses in a Community',
-                params: [
-                    {
-                        name: 'cid',
-                        type: 'CommunityIdentifier',
-                        isOptional: false
-                    },
-                    {
-                        name: 'at',
-                        type: 'Hash',
-                        isOptional: true
-                    }
-                ],
-                type: 'Vec<BusinessData>'
-            },
-            bazaarGetOfferings: {
-                description: 'Get all offerings in a Community',
-                params: [
-                    {
-                        name: 'cid',
-                        type: 'CommunityIdentifier',
-                        isOptional: false
-                    },
-                    {
-                        name: 'at',
-                        type: 'Hash',
-                        isOptional: true
-                    }
-                ],
-                type: 'Vec<OfferingData>'
-            },
-            bazaarGetOfferingsForBusiness: {
-                description: 'Get all offerings of a business',
-                params: [
-                    {
-                        name: 'bid',
-                        type: 'BusinessIdentifier',
-                        isOptional: false
-                    },
-                    {
-                        name: 'at',
-                        type: 'Hash',
-                        isOptional: true
-                    }
-                ],
-                type: 'Vec<OfferingData>'
-            }
-        }
-    },
+    rpc: {},
     types: {
         BusinessIdentifier: {
             communityIdentifier: 'CommunityIdentifier',

--- a/packages/types/src/interfaces/bazaar/types.ts
+++ b/packages/types/src/interfaces/bazaar/types.ts
@@ -14,7 +14,7 @@ export interface BusinessData extends Struct {
 
 /** @name BusinessIdentifier */
 export interface BusinessIdentifier extends Struct {
-  readonly community_identifier: CommunityIdentifier;
+  readonly communityIdentifier: CommunityIdentifier;
   readonly controller: AccountId;
 }
 

--- a/packages/types/src/interfaces/ceremony/definitions.ts
+++ b/packages/types/src/interfaces/ceremony/definitions.ts
@@ -1,6 +1,6 @@
 export default {
   rpc: {
-      ceremonies: {
+      encointer: {
           getReputations: {
               description: 'Get all reputations of an account in any community',
               params: [

--- a/packages/types/src/interfaces/ceremony/definitions.ts
+++ b/packages/types/src/interfaces/ceremony/definitions.ts
@@ -1,24 +1,5 @@
 export default {
-  rpc: {
-      encointer: {
-          getReputations: {
-              description: 'Get all reputations of an account in any community',
-              params: [
-                  {
-                      name: 'account',
-                      type: 'AccountId',
-                      isOptional: false
-                  },
-                  {
-                      name: 'at',
-                      type: 'Hash',
-                      isOptional: true
-                  }
-              ],
-              type: 'Vec<(CeremonyIndexType, CommunityReputation)>'
-          },
-      },
-  },
+  rpc: {},
   types: {
     CeremonyIndexType: 'u32',
     CeremonyPhaseType: {

--- a/packages/types/src/interfaces/common/definitions.ts
+++ b/packages/types/src/interfaces/common/definitions.ts
@@ -1,10 +1,120 @@
 export default {
-  rpc: {},
-  types: {
-    PalletString: 'Text',
-    IpfsCid: 'Text',
-    FixedI64F64: {
-      bits: "i128"
+    rpc: {
+        encointer: {
+            getReputations: {
+                description: 'Get all reputations of an account in any community',
+                params: [
+                    {
+                        name: 'account',
+                        type: 'AccountId',
+                        isOptional: false
+                    },
+                    {
+                        name: 'at',
+                        type: 'Hash',
+                        isOptional: true
+                    }
+                ],
+                type: 'Vec<(CeremonyIndexType, CommunityReputation)>'
+            },
+            getAllCommunities: {
+                description: 'Get the cid and name of all communities as Vec<CidNames>',
+                params: [
+                    {
+                        name: 'at',
+                        type: 'Hash',
+                        isOptional: true
+                    }
+                ],
+                type: 'Vec<CidName>'
+            },
+            getLocations: {
+                description: 'Get all registered locations of a community',
+                params: [
+                    {
+                        name: 'cid',
+                        type: 'CommunityIdentifier',
+                        isOptional: false
+                    },
+                    {
+                        name: 'at',
+                        type: 'Hash',
+                        isOptional: true
+                    }
+                ],
+                type: 'Vec<LocationRpc>'
+            },
+            getAllBalances: {
+                description: 'Get all non-zero balances for account in all communities',
+                params: [
+                    {
+                        name: 'account',
+                        type: 'AccountId',
+                        isOptional: false
+                    },
+                    {
+                        name: 'at',
+                        type: 'Hash',
+                        isOptional: true
+                    }
+                ],
+                type: 'Vec<(CommunityIdentifier, BalanceEntry)>'
+            },
+            bazaarGetBusinesses: {
+                description: 'Get all businesses in a Community',
+                params: [
+                    {
+                        name: 'cid',
+                        type: 'CommunityIdentifier',
+                        isOptional: false
+                    },
+                    {
+                        name: 'at',
+                        type: 'Hash',
+                        isOptional: true
+                    }
+                ],
+                type: 'Vec<BusinessData>'
+            },
+            bazaarGetOfferings: {
+                description: 'Get all offerings in a Community',
+                params: [
+                    {
+                        name: 'cid',
+                        type: 'CommunityIdentifier',
+                        isOptional: false
+                    },
+                    {
+                        name: 'at',
+                        type: 'Hash',
+                        isOptional: true
+                    }
+                ],
+                type: 'Vec<OfferingData>'
+            },
+            bazaarGetOfferingsForBusiness: {
+                description: 'Get all offerings of a business',
+                params: [
+                    {
+                        name: 'bid',
+                        type: 'BusinessIdentifier',
+                        isOptional: false
+                    },
+                    {
+                        name: 'at',
+                        type: 'Hash',
+                        isOptional: true
+                    }
+                ],
+                type: 'Vec<OfferingData>'
+            }
+        },
+    },
+    types: {
+        PalletString: 'Text',
+        IpfsCid: 'Text',
+        FixedI64F64: {
+            bits: "i128"
+        }
     }
-  }
 };

--- a/packages/types/src/interfaces/community/definitions.ts
+++ b/packages/types/src/interfaces/community/definitions.ts
@@ -1,7 +1,7 @@
 export default {
   rpc: {
-    communities: {
-      getAll: {
+    encointer: {
+      getAllCommunities: {
         description: 'Get the cid and name of all communities as Vec<CidNames>',
         params: [
           {

--- a/packages/types/src/interfaces/community/definitions.ts
+++ b/packages/types/src/interfaces/community/definitions.ts
@@ -1,51 +1,5 @@
 export default {
-  rpc: {
-    encointer: {
-      getAllCommunities: {
-        description: 'Get the cid and name of all communities as Vec<CidNames>',
-        params: [
-          {
-            name: 'at',
-            type: 'Hash',
-            isOptional: true
-          }
-        ],
-        type: 'Vec<CidName>'
-      },
-      getLocations: {
-        description: 'Get all registered locations of a community',
-        params: [
-          {
-            name: 'cid',
-            type: 'CommunityIdentifier',
-            isOptional: false
-          },
-          {
-            name: 'at',
-            type: 'Hash',
-            isOptional: true
-          }
-        ],
-        type: 'Vec<LocationRpc>'
-      },
-      getAllBalances: {
-        description: 'Get all non-zero balances for account in all communities',
-        params: [
-          {
-            name: 'account',
-            type: 'AccountId',
-            isOptional: false
-          },
-          {
-            name: 'at',
-            type: 'Hash',
-            isOptional: true
-          }
-        ],
-        type: 'Vec<(CommunityIdentifier, BalanceEntry)>'
-      }
-    }
-  },
+  rpc: {},
   types: {
     CommunityIdentifier: {
       geohash: 'GeoHash',


### PR DESCRIPTION
* Closes #59 

I had to move all rpcs into the `commons` module as the prefixes overwrote each other if defined in separate modules.