### PR TITLE
[worker-api] move definition of `isPubKeyPinPair` to common

### DIFF
--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -1,8 +1,6 @@
 import assert from 'assert';
 import type { KeyringPair } from "@polkadot/keyring/types";
-import type { PubKeyPinPair } from "@encointer/worker-api";
 import { Keyring } from "@polkadot/keyring";
-import { isPubKeyPinPair } from "@encointer/worker-api/interface";
 import BN from "bn.js";
 
 interface assertLengthFunc {
@@ -16,6 +14,15 @@ export const assertLength: assertLengthFunc = function (upper, lower) {
   assert(!(len & (len - 1)), `Bit length should be power of 2, provided ${len}`);
   return len;
 };
+
+export interface PubKeyPinPair {
+  pubKey: string,
+  pin: string,
+}
+
+export function isPubKeyPinPair(pair: KeyringPair | PubKeyPinPair) {
+  return (pair as PubKeyPinPair).pin !== undefined;
+}
 
 export const toAccount = (accountOrPubKey: (KeyringPair | PubKeyPinPair), keyring?: Keyring): KeyringPair => {
   if (isPubKeyPinPair(accountOrPubKey)) {

--- a/packages/worker-api/src/interface.ts
+++ b/packages/worker-api/src/interface.ts
@@ -17,15 +17,6 @@ export interface WorkerOptions {
   createWebSocket?: (url: string) => WebSocket;
 }
 
-export interface PubKeyPinPair {
-  pubKey: string,
-  pin: string,
-}
-
-export function isPubKeyPinPair(pair: KeyringPair | PubKeyPinPair) {
-  return (pair as PubKeyPinPair).pin !== undefined;
-}
-
 export interface TrustedGetterArgs {
   cid: string;
   account: KeyringPair;

--- a/packages/worker-api/src/trustedCallApi.ts
+++ b/packages/worker-api/src/trustedCallApi.ts
@@ -1,4 +1,4 @@
-import type { IEncointerWorker, PubKeyPinPair } from "./interface.js"
+import type { IEncointerWorker } from "./interface.js"
 import type {
   BalanceTransferArgs, CommunityIdentifier,
   GrantReputationArgs,
@@ -9,7 +9,7 @@ import type {
 import type { KeyringPair } from "@polkadot/keyring/types";
 import type { u32 } from "@polkadot/types";
 import bs58 from "bs58";
-import { toAccount } from "@encointer/util/common";
+import { toAccount, PubKeyPinPair } from "@encointer/util/common";
 
 export type TrustedCallArgs = (BalanceTransferArgs | RegisterParticipantArgs | RegisterAttestationsArgs | GrantReputationArgs);
 

--- a/packages/worker-api/src/worker.ts
+++ b/packages/worker-api/src/worker.ts
@@ -22,12 +22,12 @@ import type {
   SchedulerState, TrustedCallSigned
 } from '@encointer/types';
 
-import type { IEncointerWorker, WorkerOptions, CallOptions, PubKeyPinPair } from './interface.js';
+import type { IEncointerWorker, WorkerOptions, CallOptions } from './interface.js';
 import { Request } from './interface.js';
 import { parseBalance, parseNodeRSA } from './parsers.js';
 import { callGetter } from './getterApi.js';
 import { createTrustedCall } from "@encointer/worker-api/trustedCallApi";
-import { toAccount } from "@encointer/util/common";
+import { toAccount, PubKeyPinPair } from "@encointer/util/common";
 
 const unwrapWorkerResponse = (self: IEncointerWorker, data: string) => {
   /// Unwraps the value that is wrapped in all the Options and encoding from the worker.


### PR DESCRIPTION
The utils should not depend on the worker-api.